### PR TITLE
_gettext_lazy is deprecated in Django 4.0

### DIFF
--- a/isbn_field/validators.py
+++ b/isbn_field/validators.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ValidationError
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from six import string_types
 from stdnum import isbn
 


### PR DESCRIPTION
_gettext_lazy is deprecated in Django 4.0 and should be replaced by gettext_lazy for compatibility.